### PR TITLE
fix: git short-rev length

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,5 +33,5 @@ fi
 if ECR_JSON="$(aws ecr describe-repositories --output=json --repository-name "${GITHUB_PROJECT}")"; then
 	echo "::set-output name=uri::$(echo "${ECR_JSON}" | jq -r '.repositories[0].repositoryUri')"
 	echo "::set-output name=arn::$(echo "${ECR_JSON}" | jq -r '.repositories[0].repositoryArn')"
-	echo "::set-output name=label::$(printf '%.8s' "${GITHUB_SHA}")"
+	echo "::set-output name=label::$(printf '%.7s' "${GITHUB_SHA}")"
 fi


### PR DESCRIPTION
the standard git short-rev length is 7 characters, not 8